### PR TITLE
issue2

### DIFF
--- a/data/dataset_usrnet.py
+++ b/data/dataset_usrnet.py
@@ -27,7 +27,7 @@ class DatasetUSRNet(data.Dataset):
         self.patch_size = self.opt['H_size'] if self.opt['H_size'] else 96
         self.sigma_max = self.opt['sigma_max'] if self.opt['sigma_max'] is not None else 25
         self.scales = opt['scales'] if opt['scales'] is not None else [1,2,3,4]
-        self.sf_validation = opt['sf_validation'] if opt['sf_validation'] is not None else 3
+        self.sf_validation = opt['sf_validation'] if opt['sf_validation'] is not None else 1 # need to figure out why
         #self.kernels = hdf5storage.loadmat(os.path.join('kernels', 'kernels_12.mat'))['kernels']
         self.kernels = loadmat(os.path.join('kernels', 'kernels_12.mat'))['kernels']  # for validation
 

--- a/data/dataset_usrnet.py
+++ b/data/dataset_usrnet.py
@@ -112,6 +112,8 @@ class DatasetUSRNet(data.Dataset):
         k = util.single2tensor3(np.expand_dims(np.float32(k), axis=2))
         img_H, img_L = util.uint2tensor3(img_H), util.single2tensor3(img_L)
         noise_level = torch.FloatTensor([noise_level]).view([1,1,1])
+        
+        self.sf=1 #NOTICE #FIXME
 
         return {'L': img_L, 'H': img_H, 'k': k, 'sigma': noise_level, 'sf': self.sf, 'L_path': L_path, 'H_path': H_path}
 


### PR DESCRIPTION
issue2
-------
````sh
  6%|▌         | 311/5000 [4:14:07<63:49:22, 49.00s/it]
  6%|▌         | 312/5000 [4:15:00<65:16:51, 50.13s/it]21-01-02 16:46:28.223 : <epoch:312, iter:  10,000, lr:1.000e-04> G_loss: 3.337e-02 
21-01-02 16:46:28.224 : Saving the model.

  6%|▌         | 312/5000 [4:15:44<64:02:45, 49.18s/it]
Traceback (most recent call last):
  File "main_train_usrnet.py", line 221, in <module>
    main()
  File "main_train_usrnet.py", line 204, in main
    current_psnr = util.calculate_psnr(E_img, H_img, border=border)
  File "/home/renyumeng/workspace/KAIR/utils/utils_image.py", line 626, in calculate_psnr
    raise ValueError('Input images must have the same dimensions.')
ValueError: Input images must have the same dimensions.
````